### PR TITLE
AzureEventHub - Update Azure.Identity library to the latest version

### DIFF
--- a/Frends.AzureEventHub.Receive/CHANGELOG.md
+++ b/Frends.AzureEventHub.Receive/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.2.0] - 2024-08-22
+### Added
+- Updated Azure.Identity to the latest version 1.12.0.
+
 ## [2.1.0] - 2024-05-31
 ### Changed
 - Replaced the List<> with a ConcurrentBag<> for the received messages.

--- a/Frends.AzureEventHub.Receive/Frends.AzureEventHub.Receive.Tests/Frends.AzureEventHub.Receive.Tests.cs
+++ b/Frends.AzureEventHub.Receive/Frends.AzureEventHub.Receive.Tests/Frends.AzureEventHub.Receive.Tests.cs
@@ -26,7 +26,7 @@ class Receive
     private readonly string _storageAccount = "testsorage01";
     private static string _containerName;
     private readonly string _testFilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "TestFiles", "TestFile.xml");
-    private readonly string _eventHubConnectionString = Environment.GetEnvironmentVariable("EVENT_HUB_CONNECTION_STRING");
+    private readonly string _eventHubConnectionString = //Environment.GetEnvironmentVariable("EVENT_HUB_CONNECTION_STRING");
     private readonly string _blobStorageConnectionString = Environment.GetEnvironmentVariable("HiQ_AzureBlobStorage_ConnString");
     private readonly string _appID = Environment.GetEnvironmentVariable("HiQ_AzureBlobStorage_AppID");
     private readonly string _tenantID = Environment.GetEnvironmentVariable("HiQ_AzureBlobStorage_TenantID");
@@ -174,6 +174,7 @@ class Receive
         _checkpoint.BlobContainerUri = CreateContainer();
         _options.ConsumeAttemptDelay = 1;
         var result = await AzureEventHub.Receive(_consumer, _checkpoint, _options, default);
+        await Task.Delay(10000);
         Assert.IsTrue(result.Success);
         Assert.AreEqual(0, result.Errors.Count);
         Assert.IsTrue(result.Data.Count > 0);

--- a/Frends.AzureEventHub.Receive/Frends.AzureEventHub.Receive.Tests/Frends.AzureEventHub.Receive.Tests.cs
+++ b/Frends.AzureEventHub.Receive/Frends.AzureEventHub.Receive.Tests/Frends.AzureEventHub.Receive.Tests.cs
@@ -26,7 +26,7 @@ class Receive
     private readonly string _storageAccount = "testsorage01";
     private static string _containerName;
     private readonly string _testFilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "TestFiles", "TestFile.xml");
-    private readonly string _eventHubConnectionString = //Environment.GetEnvironmentVariable("EVENT_HUB_CONNECTION_STRING");
+    private readonly string _eventHubConnectionString = Environment.GetEnvironmentVariable("EVENT_HUB_CONNECTION_STRING");
     private readonly string _blobStorageConnectionString = Environment.GetEnvironmentVariable("HiQ_AzureBlobStorage_ConnString");
     private readonly string _appID = Environment.GetEnvironmentVariable("HiQ_AzureBlobStorage_AppID");
     private readonly string _tenantID = Environment.GetEnvironmentVariable("HiQ_AzureBlobStorage_TenantID");

--- a/Frends.AzureEventHub.Receive/Frends.AzureEventHub.Receive/Frends.AzureEventHub.Receive.csproj
+++ b/Frends.AzureEventHub.Receive/Frends.AzureEventHub.Receive/Frends.AzureEventHub.Receive.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFrameworks>net6.0</TargetFrameworks>
 		<LangVersion>Latest</LangVersion>
-		<Version>2.1.0</Version>
+		<Version>2.2.0</Version>
 		<Authors>Frends</Authors>
 		<Copyright>Frends</Copyright>
 		<Company>Frends</Company>
@@ -23,7 +23,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Azure.Identity" Version="1.10.3" />
+		<PackageReference Include="Azure.Identity" Version="1.12.0" />
 		<PackageReference Include="Azure.Messaging.EventHubs" Version="5.9.3" />
 		<PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.9.3" />
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />

--- a/Frends.AzureEventHub.Send/CHANGELOG.md
+++ b/Frends.AzureEventHub.Send/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.1.0] - 2024-08-22
+### Added
+- Updated Azure.Identity to the latest version 1.12.0.
+
 ## [1.0.0] - 2023-01-25
 ### Added
 - Initial implementation

--- a/Frends.AzureEventHub.Send/Frends.AzureEventHub.Send/Frends.AzureEventHub.Send.csproj
+++ b/Frends.AzureEventHub.Send/Frends.AzureEventHub.Send/Frends.AzureEventHub.Send.csproj
@@ -9,7 +9,7 @@
     <IncludeSource>true</IncludeSource>
     <PackageTags>Frends</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <Description>Task for sending events to Azure Event Hub.</Description>
   </PropertyGroup>
 
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.8.1" />
+    <PackageReference Include="Azure.Identity" Version="1.12.0" />
     <PackageReference Include="Azure.Messaging.EventHubs" Version="5.7.5" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />


### PR DESCRIPTION
Closes #14 . Azure.Identity -library has been updated to the latest version (1.12.0) on both Send- and Receive-tasks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Updated the `Azure.Identity` library to version 1.12.0 for improved identity management in both the Receive and Send modules.

- **Chores**
	- Incremented project versions to 2.2.0 for Receive and 1.1.0 for Send to reflect the latest updates.
  
- **Tests**
	- Added a delay in the `ReceiveEvents_OAuth2_Success` test to accommodate asynchronous operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->